### PR TITLE
Fix rectangle movement to account for mouse offset during drag

### DIFF
--- a/src/lib/main.svelte.ts
+++ b/src/lib/main.svelte.ts
@@ -25,9 +25,9 @@ export class Rectangle implements DesenhucaShape {
 		this.options = options || {};
 	}
 
-	move(x: number, y: number): void {
-		this.x += x - this.x;
-		this.y += y - this.y;
+	move(x: number, y: number, offset_x: number, offset_y: number): void {
+		this.x = x - offset_x;
+		this.y = y - offset_y;
 	}
 
 	resize(x: number, y: number): void {
@@ -37,12 +37,6 @@ export class Rectangle implements DesenhucaShape {
 
 	draw(rough: RoughCanvas): void {
 		rough.rectangle(this.x, this.y, this.width, this.height, this.options);
-
-		// rough.rectangle(this.x - 10, this.y - 10, this.width + 10, this.height + 10, options);
-		// rough.rectangle(this.x - 15, this.y - 15, size, size, options);
-		// rough.rectangle(this.width + this.x + 5, this.y - 15, size, size, options);
-		// rough.rectangle(this.x - 15, this.height + this.y + 5, size, size, options);
-		// rough.rectangle(this.width + this.x + 5, this.height + this.y + 5, size, size, options);
 	}
 
 	customize(options: DesenhucaShapeOptions): void {
@@ -67,7 +61,7 @@ export class Rectangle implements DesenhucaShape {
 		);
 	}
 
-	coords(): Point[] {
+	dimensions(): Point[] {
 		return [
 			{ x: this.x, y: this.y },
 			{ x: this.x + this.width, y: this.y + this.height }

--- a/src/lib/qudtree.ts
+++ b/src/lib/qudtree.ts
@@ -1,4 +1,4 @@
-import type { Point } from './types';
+import type { DesenhucaShape, Point } from './types';
 
 export class AABB {
 	x: number;
@@ -46,7 +46,7 @@ export class QuadTree {
 	}
 
 	insert(shape: DesenhucaShape): boolean {
-		const points = shape.coords();
+		const points = shape.dimensions();
 
 		if (!points.every((p) => this.boundary.contains(p))) {
 			return false;
@@ -108,7 +108,7 @@ export class QuadTree {
 		if (!this.boundary.intersects(range)) return found;
 
 		for (const shape of this.shapes) {
-			const points = shape.coords();
+			const points = shape.dimensions();
 
 			if (points.every((p) => range.contains(p))) {
 				found.push(shape);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,13 +3,15 @@ import type { Options } from 'roughjs/bin/core';
 import type { ShapeKind } from './consts';
 
 export interface DesenhucaShape {
+	x: number;
+	y: number;
 	customize(options: DesenhucaShapeOptions): void;
-	move(x: number, y: number): void;
+	move(x: number, y: number, offset_x: number, offset_y: number): void;
 	resize(x: number, y: number): void;
 	draw(rough: RoughCanvas): void;
 	intersects(point: Point): boolean;
 	contains(point: Point): boolean;
-	coords(): Point[];
+	dimensions(): Point[];
 	highlight(rough: RoughCanvas): void;
 }
 


### PR DESCRIPTION
The shape was not accounting the offset of the mouse when dragging, cause a jump effect to the bounds of the cursor. 